### PR TITLE
Fix geocoder's key on figaro initializer

### DIFF
--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -5,6 +5,6 @@ keys = %w[SECRET_KEY_BASE]
 unless env.development? || env.test?
   keys += %w[DB_DATABASE DB_PASSWORD DB_USERNAME]
   keys += %w[MAILER_SMTP_ADDRESS MAILER_SMTP_DOMAIN MAILER_SMTP_PORT MAILER_SMTP_USER_NAME MAILER_SMTP_PASSWORD]
-  keys += %w[GEOCODER_LOOKUP_APP_ID GEOCODER_LOOKUP_APP_CODE]
+  keys += %w[HERE_API_KEY]
 end
 Figaro.require_keys(keys)


### PR DESCRIPTION
As last upgrade to Decidim version to release/0.23-stable, geocoder's configuration has changed, deprecating old geocoders vars `GEOCODER_LOOKUP_APP_ID`, `GEOCODER_LOOKUP_APP_CODE` use in order the `HERE_API_KEY` new one.

This PR changes `Figaro` initializer geocoder's config vars.